### PR TITLE
Add new image smoketest

### DIFF
--- a/common/collect_data.yaml
+++ b/common/collect_data.yaml
@@ -46,7 +46,7 @@
   register: ver_and_id
 
 - name: Set facts (version, commit ID, redhat-release, os-release)
-  set_fact: 
+  set_fact:
     atomic_host_status: "{{ ahs.stdout }}"
     atomic_ver: "{{ ver_and_id.stdout.split()[0] }}"
     commit_id: "{{ ver_and_id.stdout.split()[1] }}"
@@ -58,7 +58,7 @@
   when: ansible_distribution == "RedHat"
 
 - name: Record ostree signature
-  shell: ostree show "{{ commit_id }}" 
+  shell: ostree show "{{ commit_id }}"
   register: ostree_sig
 
 - name: Collect info about "key" packages

--- a/common/output_files.yaml
+++ b/common/output_files.yaml
@@ -15,6 +15,7 @@
 #
 - name: Generate diff of RPM lists for template
   include: rpm_diffs.yaml
+  when: upgraded_rpms is defined
 
 - name: Generate the smoke test content with a template
   template:

--- a/templates/atomic_smoke_output.j2
+++ b/templates/atomic_smoke_output.j2
@@ -15,12 +15,14 @@ Key Packages
 {{ atomic_pkgs.stdout }}
 {% endif %}
 
-RPM Diffs between {{ initial_atomic_version.stdout }} and {{ upgraded_atomic_version.stdout }}
-====================================
-{% if rpm_diffs.rc == 0 %}
-No package changes!
-{% elif rpm_diffs.rc == 1 %}
-{{ rpm_diffs.stdout }}
-{% else %}
-Unable to determine package changes!
+{% if upgraded_atomic_version is defined%}
+    RPM Diffs between {{ initial_atomic_version.stdout }} and {{ upgraded_atomic_version.stdout }}
+    ====================================
+    {% if rpm_diffs.rc == 0 %}
+    No package changes!
+    {% elif rpm_diffs.rc == 1 %}
+    {{ rpm_diffs.stdout }}
+    {% else %}
+    Unable to determine package changes!
+    {% endif %}
 {% endif %}

--- a/tests/new-image-smoketest/main.yaml
+++ b/tests/new-image-smoketest/main.yaml
@@ -1,11 +1,11 @@
 ---
 # vim: set ft=ansible:
 #
-# A playbook that performs a simple smoke test of Atomic Host upgrading to
-# a new ostree.
+# This playbook performs a simple smoketest of a new Atomic Host cloud image.
 #
-# This basically just does an upgrade, reboot, rollback, and reboot on an
-# Atomic Host.
+# The test assumes that new ostree content and cloud image have been released
+# simultaneously.  Therefore, it tests if an upgrade is available (it shouldn't
+# be) and if a rollback is possilbe (also should not be).
 #
 # If the 'jenkins' tag is not skipped, it also performs some data gathering
 # operations which will generate output files on the host that can be
@@ -20,15 +20,12 @@
 #
 # See `tests/new-tree-smoketest/group_vars/all` for example values
 #
-- name: Atomic Host new tree smoketest
+- name: Atomic Host new image smoketest
   hosts: all
   sudo: yes
 
   vars_files:
     - ../../vars/smoketest_vars.yaml
-
-  vars:
-    - upgraded_rpms: "upgraded_rpm_list.txt"
 
   tasks:
     - name: Check if system is an Atomic Host
@@ -52,24 +49,15 @@
       tags:
         - jenkins
 
-    - name: Upgrade to latest tree
-      shell: atomic host upgrade | tee atomic_host_upgrade
-      args:
-        chdir: "{{ datadir }}"
+    - name: Check for available upgrade
+      shell: atomic host upgrade
+      register: upgrade
+      failed_when: "upgrade.rc < 77"
 
-    - name: Reboot the host
-      include: ../../common/ans_reboot.yaml
-
-    - name: Gather upgraded RPM list
-      include: ../../common/rpm_list.yaml rpm_file="{{ upgraded_rpms }}"
-      tags:
-        - jenkins
-
-    - name: Get upgraded atomic version
-      shell: atomic host status | awk '/^*/{print $4}'
-      register: upgraded_atomic_version
-      tags:
-        - jenkins
+    - name: Check for available rollback
+      shell: atomic host rollback
+      register: rollback
+      failed_when: "rollback.rc != 1"
 
     - name: Gather data about system
       include: ../../common/collect_data.yaml
@@ -80,12 +68,6 @@
       include: ../../common/output_files.yaml
       tags:
         - jenkins
-
-    - name: Rollback to previous deployment
-      shell: atomic host rollback
-
-    - name: Reboot into previous deployment
-      include: ../../common/ans_reboot.yaml
 
     - name: Remove all registrations using subscription-manager
       include: ../../rhel/unsubscribe.yaml

--- a/vars/smoketest_vars.yaml
+++ b/vars/smoketest_vars.yaml
@@ -3,23 +3,22 @@ subscription_file: "prod_data.csv"
 datadir: "/var/qe"
 output_file: "atomic_smoke_output.txt"
 version_file: "atomic_version.txt"
-initial_rpms: "initial_rpm_list.txt"
-upgraded_rpms: "upgraded_rpm_list.txt"
+initial_rpms: "initial_rpms_list.txt"
 redhat_release: "Red Hat Enterprise Linux Atomic Host"
 fedora_release: "Fedora"
 centos_release: "CentOS Linux"
 redhat_key_id: "199E2F91FD431D51"
 fedora_key_id: "32474CF834EC9CBA"
 centos_key_id: "F17E745691BA8335"
-key_pkgs_list: 
-  - atomic 
-  - docker 
-  - docker-selinux 
+key_pkgs_list:
+  - atomic
+  - docker
+  - docker-selinux
   - etcd
-  - flannel 
-  - kernel 
-  - kubernetes 
-  - kubernetes-client 
-  - kubernetes-master 
-  - kubernetes-node 
+  - flannel
+  - kernel
+  - kubernetes
+  - kubernetes-client
+  - kubernetes-master
+  - kubernetes-node
   - python-docker-py


### PR DESCRIPTION
This adds a simple smoketest that assumes a new cloud image has been
released and there are no updates available.  It tests to verify that an
upgrade is not possible, as well as a rollback is not possible.

`common/collect_data.yaml`
  - Clean up trailing whitespace

`common/output_files.yaml`
  - Changed the RPM diff task to only run when the `upgraded_rpms` var
    is defined

`templates/atomic_smoke_output.j2`
  - Changed the template to only generate RPM diff content if the
    `upgraded_atomic_version` variable is defined

`tests/new-image-smoketest/main.yaml`
  - New playbook for cloud images

`tests/new-tree-smoketest/main.yaml`
  - Changed to include the var file

`vars/smoketest_vars.yaml`
  - Moved the vars from `group_vars/all` to a common file that can be
    included