### PR TITLE
new-tree-smoketest: add pkg downgrade check

### DIFF
--- a/common/scripts/check_downgrade.py
+++ b/common/scripts/check_downgrade.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+from distutils.version import LooseVersion
+import re
+import sys
+
+
+def warn_downgrade(msg):
+    print("WARN: Possible downgrade detected! ", msg, file=sys.stderr)
+
+
+def check_downgrade(line):
+    '''
+    Tests to see if the line has the correct amount of words and then does
+    a version compare to determine if a package was downgraded.
+
+    Looking for lines like this:
+
+    kernel 3.10.0-229.14.1.el7 -> 3.10.0-324.el7
+    '''
+    rc = 0
+    words = line.split()
+    if len(words) != 4:
+        pass
+    elif LooseVersion(words[1]) > LooseVersion(words[3]):
+        warn_downgrade(line.strip())
+        rc = 1
+
+    return rc
+
+
+def main():
+    exit_status = 0
+    if len(sys.argv) == 2:
+        filename = sys.argv[1]
+    else:
+        print("ERR: Need to supply filename!", file=sys.stderr)
+        sys.exit(1)
+
+    with open(filename, 'r') as f:
+        for l in f:
+            # check if the line starts with 2 spaces
+            if re.search('^  ', l):
+                if check_downgrade(l):
+                    exit_status = 1
+            else:
+                pass
+
+    sys.exit(exit_status)
+
+if __name__ == "__main__":
+    main()

--- a/rhel/subscribe.yaml
+++ b/rhel/subscribe.yaml
@@ -8,6 +8,8 @@
 # Expects the following variable to be defined:
 #  - subscription_file
 #
+# NOTE: The 'subscription_file' variable lives in var/smoketest_vars.yaml
+#
 # NOTE: It is suggested that the value of `subscription_file` point to a file
 #       that is dropped into the same directory as this task file.  This will
 #       reduce any difficulties trying to determine the right path for the

--- a/tests/new-tree-smoketest/main.yaml
+++ b/tests/new-tree-smoketest/main.yaml
@@ -41,6 +41,12 @@
     - name: Setup data directory
       include: ../../common/data_dir.yaml
 
+    - name: Copy downgrade check script
+      copy:
+        dest: "{{ datadir }}/check_downgrade.py"
+        mode: 0744
+        src: ../../common/scripts/check_downgrade.py
+
     - name: Gather initial RPM list
       include: ../../common/rpm_list.yaml rpm_file="{{ initial_rpms }}"
       tags:
@@ -56,6 +62,9 @@
       shell: atomic host upgrade | tee atomic_host_upgrade
       args:
         chdir: "{{ datadir }}"
+
+    - name: Run downgrade check script
+      command: "{{ datadir }}/check_downgrade.py {{ datadir }}/atomic_host_upgrade"
 
     - name: Reboot the host
       include: ../../common/ans_reboot.yaml

--- a/vars/smoketest_vars.yaml
+++ b/vars/smoketest_vars.yaml
@@ -1,5 +1,5 @@
 ---
-subscription_file: "prod_data.csv"
+subscription_file: "subscription_data.csv"
 datadir: "/var/qe"
 output_file: "atomic_smoke_output.txt"
 version_file: "atomic_version.txt"


### PR DESCRIPTION
This adds a Python script to check the recorded output of `atomic host
upgrade` for any packages that may have been downgraded as part of the
upgrade to a new tree.

Additionally, the variable used by the `subscribe` task was changed to
be more meaningful.