### PR TITLE
Add check for wonky /tmp

### DIFF
--- a/common/check_tmp_perms.yaml
+++ b/common/check_tmp_perms.yaml
@@ -1,0 +1,15 @@
+---
+# vim: set ft=ansible:
+#
+# Simple task to verify that the permissions on /tmp are correct.  See
+# associated BZ 1276775 - https://bugzilla.redhat.com/show_bug.cgi?id=1276775
+#
+- name: Get info about /tmp
+  stat:
+    path: /tmp
+  register: s
+
+- name: Fail if something on /tmp is fishy
+  fail:
+    msg: "Permissions or ownership on /tmp is incorrect"
+  when: s.stat.mode != "0777" or s.stat.gr_name != "root" or s.stat.pw_name != "root"

--- a/tests/new-image-smoketest/main.yaml
+++ b/tests/new-image-smoketest/main.yaml
@@ -38,6 +38,9 @@
     - name: Setup data directory
       include: ../../common/data_dir.yaml
 
+    - name: Check /tmp (BZ 1276775)
+      include: ../../common/check_tmp_perms.yaml
+
     - name: Gather initial RPM list
       include: ../../common/rpm_list.yaml rpm_file="{{ initial_rpms }}"
       tags:

--- a/tests/new-tree-smoketest/main.yaml
+++ b/tests/new-tree-smoketest/main.yaml
@@ -69,6 +69,9 @@
     - name: Reboot the host
       include: ../../common/ans_reboot.yaml
 
+    - name: Check /tmp (BZ 1276775)
+      include: ../../common/check_tmp_perms.yaml
+
     - name: Gather upgraded RPM list
       include: ../../common/rpm_list.yaml rpm_file="{{ upgraded_rpms }}"
       tags:


### PR DESCRIPTION
There is an old BZ ([1276775](https://bugzilla.redhat.com/show_bug.cgi?id=1276775)) that reported bad permissions on `/tmp`; this
change adds a check for bad permissions and bad ownership on `/tmp`.