### PR TITLE
ans_reboot: Make reboot more reliable

### DIFF
--- a/common/ans_reboot.yaml
+++ b/common/ans_reboot.yaml
@@ -20,9 +20,9 @@
 # anyway.
 
 - name: wait for hosts to come down
-  local_action: wait_for host={{ inventory_hostname }} port=22 state=stopped
+  local_action: wait_for host={{ ansible_default_ipv4.address }} port=22 state=stopped
   sudo: false
 
 - name: wait for hosts to come back up
-  local_action: wait_for host={{ inventory_hostname }} port=22 state=started
+  local_action: wait_for host={{ ansible_default_ipv4.address }} port=22 state=started
   sudo: false


### PR DESCRIPTION
Previously we used `inventory_hostname` as an argument to the `wait_for`
module.  But this did not always work with hostnames that were only
defined in the `inventory` file.  Switching to using the IP address of
the host via `ansible_default_ipv4.address` allows the playbook to be
run with an `inventory` file or with an inventory argument on the
command line like:

`ansible-playbook -i "192.168.122.34," -u cloud-user tests/new-tree-smoektest/main.yaml`