### PR TITLE
rpm_diffs: Changing how rpm diff fails

### DIFF
--- a/common/rpm_diffs.yaml
+++ b/common/rpm_diffs.yaml
@@ -13,8 +13,8 @@
   args:
     chdir: "{{ datadir }}"
   register: diffs
-  ignore_errors: yes
   no_log: True
+  failed_when: diffs.rc != 1
 
 - name: Set RPM diff fact
   set_fact:


### PR DESCRIPTION
When running `diff` we only care if the return code is 1 (indicating a
difference between the two files), so all other return codes are
failures.