### PR TITLE
Change location of 'subscription_file' variable

### DIFF
--- a/tests/new-image-smoketest/main.yaml
+++ b/tests/new-image-smoketest/main.yaml
@@ -26,6 +26,7 @@
 
   vars_files:
     - ../../vars/smoketest_vars.yaml
+    - ../../vars/subscription.yaml
 
   tasks:
     - name: Check if system is an Atomic Host

--- a/tests/new-tree-smoketest/main.yaml
+++ b/tests/new-tree-smoketest/main.yaml
@@ -26,6 +26,7 @@
 
   vars_files:
     - ../../vars/smoketest_vars.yaml
+    - ../../vars/subscription.yaml
 
   vars:
     - upgraded_rpms: "upgraded_rpm_list.txt"

--- a/vars/smoketest_vars.yaml
+++ b/vars/smoketest_vars.yaml
@@ -1,5 +1,4 @@
 ---
-subscription_file: "subscription_data.csv"
 datadir: "/var/qe"
 output_file: "atomic_smoke_output.txt"
 version_file: "atomic_version.txt"

--- a/vars/subscription.yaml
+++ b/vars/subscription.yaml
@@ -1,0 +1,2 @@
+---
+subscription_file: "subscription_data.csv"


### PR DESCRIPTION
This moves the definition of the `subscription_file` variable to a
separate var file, in the attempt to minimize the amount of variables to
include for future tests.