### PR TITLE
Add multiple rollback tests

### DIFF
--- a/common/compare_version.yaml
+++ b/common/compare_version.yaml
@@ -1,0 +1,45 @@
+---
+# vim: set ft=ansible:
+#
+# Task that compares the version of the deployment in the first position to
+# an expected value
+#
+# Some extra leg work was required to properly extract the version of the
+# first deployment since the number of fields (in terms of 'awk') can vary
+# if the deployment is booted or not.
+- name: Determine if first deployment is booted
+  shell: rpm-ostree status | awk 'FNR == 2 {print NF}'
+  register: b
+
+- name: Init the is_booted fact
+  set_fact:
+    is_booted: false
+
+- name: Set the is_booted fact
+  set_fact:
+    is_booted: true
+  when: b.stdout == "7"
+
+- name: Get deployment in first position when not booted
+  shell: rpm-ostree status | awk 'FNR == 2 {print $3}'
+  register: not_booted_f
+  when: not is_booted
+
+- name: Get deployment in first position when booted
+  shell: rpm-ostree status | awk 'FNR ==2 {print $4}'
+  register: is_booted_f
+  when: is_booted
+
+- name: Set first_version fact when not booted
+  set_fact:
+    first_version: "{{ not_booted_f.stdout }}"
+  when: not is_booted
+
+- name: Set first_version fact when booted
+  set_fact:
+    first_version: "{{ is_booted_f.stdout }}"
+  when: is_booted
+
+- name: Fail if the version is not expected
+  fail: msg="The first deployment version {{ first_version }} did not match the expected version {{ expected_version }}"
+  when: first_version != expected_version

--- a/common/multiple_rollback.yaml
+++ b/common/multiple_rollback.yaml
@@ -1,0 +1,77 @@
+---
+# vim: set ft=ansible:
+#
+# Task that performs multiple rollback cycles
+#
+- name: Get deployment in first position
+  shell: rpm-ostree status | awk 'FNR == 2 {print $4}'
+  register: f
+
+- set_fact: original_version="{{ f.stdout }}"
+
+- name: Get deployment in second position
+  shell: rpm-ostree status | awk 'FNR == 3 {print $3}'
+  register: s
+
+- set_fact: secondary_version="{{ s.stdout }}"
+
+- name: Rollback #1 (to secondary deployment)
+  command: atomic host rollback
+
+- name: Check version is in first position is correct (should be secondary version)
+  include: compare_version.yaml expected_version="{{ secondary_version }}"
+
+- name: Rollback #2 (to original deployment)
+  command: atomic host rollback
+
+- name: Check version is in first position is correct (should be original version)
+  include: compare_version.yaml expected_version="{{ original_version }}"
+
+- name: Rollback #3 (to secondary deployment)
+  command: atomic host rollback
+
+- name: Check version is in first position is correct (should be secondary version)
+  include: compare_version.yaml expected_version="{{ secondary_version }}"
+
+- name: Rollback #4 (to original deployment)
+  command: atomic host rollback
+
+- name: Check version is in first position is correct (should be original version)
+  include: compare_version.yaml expected_version="{{ original_version }}"
+
+- name: Rollback #5 (to secondary deployment)
+  command: atomic host rollback
+
+- name: Check version is in first position is correct (should be secondary version)
+  include: compare_version.yaml expected_version="{{ secondary_version }}"
+
+- name: Rollback #6 (to original deployment)
+  command: atomic host rollback
+
+- name: Check version is in first position is correct (should be original version)
+  include: compare_version.yaml expected_version="{{ original_version }}"
+
+- name: Rollback #7 (to secondary deployment)
+  command: atomic host rollback
+
+- name: Check version is in first position is correct (should be secondary version)
+  include: compare_version.yaml expected_version="{{ secondary_version }}"
+
+- name: Rollback #8 (to original deployment)
+  command: atomic host rollback
+
+- name: Check version is in first position is correct (should be original version)
+  include: compare_version.yaml expected_version="{{ original_version }}"
+
+- name: Rollback #9 (to secondary deployment)
+  command: atomic host rollback
+
+- name: Check version is in first position is correct (should be secondary version)
+  include: compare_version.yaml expected_version="{{ secondary_version }}"
+
+- name: Rollback #10 (to original deployment)
+  command: atomic host rollback
+
+- name: Check version is in first position is correct (should be original version)
+  include: compare_version.yaml expected_version="{{ original_version }}"
+

--- a/common/multiple_rollback_reboot.yaml
+++ b/common/multiple_rollback_reboot.yaml
@@ -1,0 +1,106 @@
+---
+# vim: set ft=ansible:
+#
+# Task that performs multiple rollback/reboot cycles
+#
+- name: Get deployment in first position
+  shell: rpm-ostree status | awk 'FNR == 2 {print $4}'
+  register: f
+
+- set_fact: original_version="{{ f.stdout }}"
+
+- name: Get deployment in second position
+  shell: rpm-ostree status | awk 'FNR == 3 {print $3}'
+  register: s
+
+- set_fact: secondary_version="{{ s.stdout }}"
+
+- name: Rollback #1 (to secondary deployment)
+  command: atomic host rollback
+
+- name: Reboot #1
+  include: ans_reboot.yaml
+
+- name: Check version is in first position is correct (should be secondary version)
+  include: compare_version.yaml expected_version="{{ secondary_version }}"
+
+- name: Rollback #2 (to original deployment)
+  command: atomic host rollback
+
+- name: Reboot #2
+  include: ans_reboot.yaml
+
+- name: Check version is in first position is correct (should be original version)
+  include: compare_version.yaml expected_version="{{ original_version }}"
+
+- name: Rollback #3 (to secondary deployment)
+  command: atomic host rollback
+
+- name: Reboot #3
+  include: ans_reboot.yaml
+
+- name: Check version is in first position is correct (should be secondary version)
+  include: compare_version.yaml expected_version="{{ secondary_version }}"
+
+- name: Rollback #4 (to original deployment)
+  command: atomic host rollback
+
+- name: Reboot #4
+  include: ans_reboot.yaml
+
+- name: Check version is in first position is correct (should be original version)
+  include: compare_version.yaml expected_version="{{ original_version }}"
+
+- name: Rollback #5 (to secondary deployment)
+  command: atomic host rollback
+
+- name: Reboot #5
+  include: ans_reboot.yaml
+
+- name: Check version is in first position is correct (should be secondary version)
+  include: compare_version.yaml expected_version="{{ secondary_version }}"
+
+- name: Rollback #6 (to original deployment)
+  command: atomic host rollback
+
+- name: Reboot #6
+  include: ans_reboot.yaml
+
+- name: Check version is in first position is correct (should be original version)
+  include: compare_version.yaml expected_version="{{ original_version }}"
+
+- name: Rollback #7 (to secondary deployment)
+  command: atomic host rollback
+
+- name: Reboot #7
+  include: ans_reboot.yaml
+
+- name: Check version is in first position is correct (should be secondary version)
+  include: compare_version.yaml expected_version="{{ secondary_version }}"
+
+- name: Rollback #8 (to original deployment)
+  command: atomic host rollback
+
+- name: Reboot #8
+  include: ans_reboot.yaml
+
+- name: Check version is in first position is correct (should be original version)
+  include: compare_version.yaml expected_version="{{ original_version }}"
+
+- name: Rollback #9 (to secondary deployment)
+  command: atomic host rollback
+
+- name: Reboot #9
+  include: ans_reboot.yaml
+
+- name: Check version is in first position is correct (should be secondary version)
+  include: compare_version.yaml expected_version="{{ secondary_version }}"
+
+- name: Rollback #10 (to original deployment)
+  command: atomic host rollback
+
+- name: Reboot #10
+  include: ans_reboot.yaml
+
+- name: Check version is in first position is correct (should be original version)
+  include: compare_version.yaml expected_version="{{ original_version }}"

--- a/tests/multiple-rollback-reboot/README.md
+++ b/tests/multiple-rollback-reboot/README.md
@@ -1,0 +1,22 @@
+This playbook perfoms a test of the rollback mechanism of `rpm-ostree`.  It
+tests that the correct deployment is selected for boot after each rollback
+and subsequent reboot.
+
+### Prerequisites
+  - Configure subscription data (if used)
+
+    If running against a RHEL Atomic Host, you should provide subscription
+    data that can be used by `subscription-manager`.  See
+    [common/rhel/subscribe.yaml](https://github.com/miabbott/atomic-host-tests/blob/test-readme/rhel/subscribe.yaml) for addiltional details.
+
+### Running the Playbook
+
+To run the test, simply invoke as any other Ansible playbook:
+
+```
+$ ansible-playbook -i inventory main.yaml
+```
+
+*NOTE*: You are responsible for providing a host to run the test against and the
+inventory file for that host.
+

--- a/tests/multiple-rollback-reboot/main.yaml
+++ b/tests/multiple-rollback-reboot/main.yaml
@@ -1,0 +1,39 @@
+---
+# vim: set ft=ansible:
+#
+# This playibook tests the ability to perform multiple rollbacks in
+# succession. After eact rollback, the system is rebooted and the output
+# of 'rpm-ostree status' is examined to determine if the proper deployment
+# was booted.
+#
+# Because the playbook attempts to register the system with
+# 'subscription-manager' if it is a RHEL system, it expects to have the
+# variables in 'vars/subscription.yaml' defined.
+#
+- name: Atomic Host multiple rollback test
+  hosts: all
+  sudo: yes
+
+  vars_files:
+    - ../../vars/subscription.yaml
+
+  tasks:
+    - name: Check if system is an Atomic Host
+      include: ../../common/atomic.yaml
+
+    - name: Register using subscription-manager
+      include: ../../rhel/subscribe.yaml
+      when: ansible_distribution == "RedHat"
+
+    - name: Upgrade to latest tree
+      command: atomic host upgrade
+
+    - name: Reboot into new tree
+      include: ../../common/ans_reboot.yaml
+
+    - name: Perform rollback/reboot multiple times
+      include: ../../common/multiple_rollback_reboot.yaml
+
+    - name: Remove all registrations using subscription-manager
+      include: ../../rhel/unsubscribe.yaml
+      when: ansible_distribution == "RedHat"

--- a/tests/multiple-rollback/README.md
+++ b/tests/multiple-rollback/README.md
@@ -1,0 +1,21 @@
+This playbook perfoms a test of the rollback mechanism of `rpm-ostree`.  It
+tests that the correct deployment is selected for boot after each rollback.
+
+### Prerequisites
+  - Configure subscription data (if used)
+
+    If running against a RHEL Atomic Host, you should provide subscription
+    data that can be used by `subscription-manager`.  See
+    [common/rhel/subscribe.yaml](https://github.com/miabbott/atomic-host-tests/blob/test-readme/rhel/subscribe.yaml) for addiltional details.
+
+### Running the Playbook
+
+To run the test, simply invoke as any other Ansible playbook:
+
+```
+$ ansible-playbook -i inventory main.yaml
+```
+
+*NOTE*: You are responsible for providing a host to run the test against and the
+inventory file for that host.
+

--- a/tests/multiple-rollback/main.yaml
+++ b/tests/multiple-rollback/main.yaml
@@ -1,0 +1,40 @@
+---
+# vim: set ft=ansible:
+#
+# This playibook tests the ability to perform multiple rollbacks in
+# succession.  This just tests the ability to toggle the deployment without
+# actually rebooting into each deployment.  After each rollback, the output
+# of 'rpm-ostree status' is inspected to verify that the proper deployment
+# has been selected for boot.
+#
+# Because the playbook attempts to register the system with
+# 'subscription-manager' if it is a RHEL system, it expects to have the
+# variables in 'vars/subscription.yaml' defined.
+#
+- name: Atomic Host multiple rollback test
+  hosts: all
+  sudo: yes
+
+  vars_files:
+    - ../../vars/subscription.yaml
+
+  tasks:
+    - name: Check if system is an Atomic Host
+      include: ../../common/atomic.yaml
+
+    - name: Register using subscription-manager
+      include: ../../rhel/subscribe.yaml
+      when: ansible_distribution == "RedHat"
+
+    - name: Upgrade to latest tree
+      command: atomic host upgrade
+
+    - name: Reboot into new tree
+      include: ../../common/ans_reboot.yaml
+
+    - name: Perform rollback multiple times
+      include: ../../common/multiple_rollback.yaml
+
+    - name: Remove all registrations using subscription-manager
+      include: ../../rhel/unsubscribe.yaml
+      when: ansible_distribution == "RedHat"


### PR DESCRIPTION
These tests perform multiple rollbacks on the host to verify that the
mechanism works correctly.  After each rollback, the results of
`rpm-ostree status` are inspected to make sure the expected deployment
is in the right place.

There are two versions of the test: one just does a number of rollbacks
and the other does a rollback/reboot combination.