### PR TITLE
Playbook to test interrupting upgrade operation

### DIFF
--- a/common/scripts/atomic_upgrade_interrupt.sh
+++ b/common/scripts/atomic_upgrade_interrupt.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then
+    LOOP="10"
+else
+    LOOP=$1
+fi
+
+if [ -z "$2" ]; then
+    DELAY="10"
+else
+    DELAY="$2"
+fi
+
+UPGRADE='atomic host upgrade'
+FAILED_FILE='/var/qe/atomic_upgrade_failed'
+
+if [ -e "$FAILED_FILE" ]; then
+    rm $FAILED_FILE
+fi
+
+for l in $(seq $LOOP); do
+    echo "Attempting upgrade iteration $l of $LOOP with a delay of $DELAY seconds"
+    timeout --signal=SIGINT $DELAY $UPGRADE
+    UPGRADE_RV=$?
+    if [ "$UPGRADE_RV" -ne 124 ] && [ "$UPGRADE_RV" -ne 0 ]; then
+        echo "ERROR! The 'atomic host upgrade' command did not exit successfully or via SIGINT"
+        echo "ERROR! The reported exit status was: $UPGRADE_RV"
+        touch $FAILED_FILE
+        exit $UPGRADE_RV
+    fi
+    sleep 5
+    echo -e "\n"
+done

--- a/tests/upgrade-interrupt/README.md
+++ b/tests/upgrade-interrupt/README.md
@@ -1,0 +1,36 @@
+This playbook tests the ability to interrupt the `rpm-ostree upgrade`
+operation.  The system should not be negatively impacted after an interrupt
+(or multiple interrupts) of the `upgrade` operation.  Additionally, the
+system should be able to complete a `upgrade` operation after it had been
+interrupted.
+
+The playbook performs the interrupt via a bash script that is included at
+[common/scripts/atomic_upgrade_interrupt.sh](/common/scripts/atomic_upgrade_interrupt.sh)
+
+### Prerequisites
+  - Configure subscription data (if used)
+
+    If running against a RHEL Atomic Host, you should provide subscription
+    data that can be used by `subscription-manager`.  See
+    [rhel/subscribe.yaml](/rhel/subscribe.yaml) for addiltional details.
+
+### Running the Playbook
+
+To run the test, simply invoke as any other Ansible playbook:
+
+```
+$ ansible-playbook -i inventory main.yaml
+```
+
+To change the amount of times that the `upgrade` operation should be interrupted,
+you can use the `iterations` variable which can be passed to the playbook like this:
+
+```
+$ ansible-playbook -i inventory main.yaml -e "interations=10"
+```
+
+The default value for `iterations` is 1.
+
+*NOTE*: You are responsible for providing a host to run the test against and the
+inventory file for that host.
+

--- a/tests/upgrade-interrupt/main.yaml
+++ b/tests/upgrade-interrupt/main.yaml
@@ -1,0 +1,79 @@
+---
+# vim: set ft=ansible:
+#
+# This playbook tests the ability to interrupt a upgrade operation without
+# any negative impact to the system.
+#
+# The interrupt ability is tested via the included bash script
+# ('atomic_upgrade_interrupt.sh').  Please see the script for implementation
+# details.
+#
+# By default, the script tries to interrupt the upgrade operation once, but
+# any number of interrupts can be attempted by supplying a different value
+# to the 'iterations' variable.
+#
+# The playbook requires the following variable set:
+#   - datadir
+#
+# See the 'vars/smoketest_vars.yaml' for example values.
+#
+# Because the playbook attempts to register the system with
+# 'subscription-manager' if it is a RHEL system, it expects to have the
+# variables in 'vars/subscription.yaml' defined.
+#
+- name: Atomic Host interrupt rollback test
+  hosts: all
+  sudo: yes
+
+  vars_files:
+    - ../../vars/smoketest_vars.yaml
+    - ../../vars/subscription.yaml
+
+  tasks:
+    - name: Check if system is an Atomic Host
+      include: ../../common/atomic.yaml
+
+    - name: Register using subscription-manager
+      include: ../../rhel/subscribe.yaml
+      when: ansible_distribution == "RedHat"
+
+    - name: Setup data directory
+      include: ../../common/data_dir.yaml
+
+    - name: Copy upgrade_interrupt script to host
+      copy:
+        dest: "{{ datadir }}/atomic_upgrade_interrupt.sh"
+        mode: 0744
+        src: ../../common/scripts/atomic_upgrade_interrupt.sh
+
+    - name: Get deployment in first position
+      shell: rpm-ostree status | awk 'FNR == 2 {print $4}'
+      register: f
+
+    - set_fact: original_version="{{ f.stdout }}"
+
+    - name: Run the upgrade_interrupt script
+      command: "{{ datadir }}/atomic_upgrade_interrupt.sh {{ iterations | default('1') }}"
+
+    - name: Verify that the first deployment has NOT changed
+      include: ../../common/compare_version.yaml expected_version="{{ original_version }}"
+
+    - name: Complete the upgrade
+      command: rpm-ostree upgrade
+
+    - name: Get new first deployment
+      shell: rpm-ostree status | awk 'FNR == 2 {print $3}'
+      register: new_deployment
+
+    - name: Verify that the first deployment HAS changed
+      include: ../../common/compare_version.yaml expected_version="{{ new_deployment.stdout }}"
+
+    - name: Reboot into new tree
+      include: ../../common/ans_reboot.yaml
+
+    - name: Verify that the first deployment HAS changed after reboot
+      include: ../../common/compare_version.yaml expected_version="{{ new_deployment.stdout }}"
+
+    - name: Remove all registrations using subscription-manager
+      include: ../../rhel/unsubscribe.yaml
+      when: ansible_distribution == "RedHat"


### PR DESCRIPTION
It is possible to interrupt the upgrade process and have no negative
impact to the running system.  This playbook verifies that interrupting
the upgrade does not affect the running system or the ability to
complete an upgrade after the fact.