### PR TITLE
Revert "ans_reboot: Make reboot more reliable"

### DIFF
--- a/common/ans_reboot.yaml
+++ b/common/ans_reboot.yaml
@@ -20,9 +20,9 @@
 # anyway.
 
 - name: wait for hosts to come down
-  local_action: wait_for host={{ ansible_default_ipv4.address }} port=22 state=stopped
+  local_action: wait_for host={{ inventory_hostname }} port=22 state=stopped
   sudo: false
 
 - name: wait for hosts to come back up
-  local_action: wait_for host={{ ansible_default_ipv4.address }} port=22 state=started
+  local_action: wait_for host={{ inventory_hostname }} port=22 state=started
   sudo: false


### PR DESCRIPTION
This reverts commit 9382b2e259cdb58fcb0621ed114fbb5e2d02ab6b.

In a cloud environment, it is possible that the system under test will
not have the interface with the external IP address explicitly listed in
the output of the likes of `ip address` or `ifconfig`.  This causes the
value of `ansible_default_ipv4.address` to be a non-routable address and
cannot be used reliably, unless the host running the Ansible playbooks
is also in the same cloud environment.

We will go back to using `inventory_hostname` and will have to work
around any issues that are encountered.